### PR TITLE
Add medication registration and Room persistence

### DIFF
--- a/PreventForgettingMedicationAndroidApp/app/build.gradle.kts
+++ b/PreventForgettingMedicationAndroidApp/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.kapt)
 }
 
 android {
@@ -42,6 +43,9 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/PreventForgettingMedicationAndroidApp/app/src/main/AndroidManifest.xml
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/AndroidManifest.xml
@@ -20,6 +20,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".MedicationRegistrationActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/Converters.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/Converters.kt
@@ -1,0 +1,19 @@
+package com.example.preventforgettingmedicationandroidapp
+
+import androidx.room.TypeConverter
+
+class Converters {
+    @TypeConverter
+    fun fromMealTiming(value: MealTiming?): String? = value?.name
+
+    @TypeConverter
+    fun toMealTiming(value: String?): MealTiming? = value?.let { MealTiming.valueOf(it) }
+
+    @TypeConverter
+    fun fromIntakeSlots(slots: Set<IntakeSlot>): String =
+        slots.joinToString(",") { it.name }
+
+    @TypeConverter
+    fun toIntakeSlots(data: String): Set<IntakeSlot> =
+        if (data.isEmpty()) emptySet() else data.split(",").map { IntakeSlot.valueOf(it) }.toSet()
+}

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/IntakeSlot.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/IntakeSlot.kt
@@ -1,0 +1,3 @@
+package com.example.preventforgettingmedicationandroidapp
+
+enum class IntakeSlot { MORNING, NOON, EVENING }

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MainActivity.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.example.preventforgettingmedicationandroidapp
 
+import android.content.Intent
 import android.os.Bundle
+import android.widget.Button
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -15,6 +17,9 @@ class MainActivity : AppCompatActivity() {
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
+        }
+        findViewById<Button>(R.id.add_medication_button).setOnClickListener {
+            startActivity(Intent(this, MedicationRegistrationActivity::class.java))
         }
     }
 }

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MealTiming.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MealTiming.kt
@@ -1,0 +1,3 @@
+package com.example.preventforgettingmedicationandroidapp
+
+enum class MealTiming { BEFORE_MEAL, AFTER_MEAL }

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/Medication.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/Medication.kt
@@ -1,0 +1,12 @@
+package com.example.preventforgettingmedicationandroidapp
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "medications")
+data class Medication(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val name: String,
+    val mealTiming: MealTiming?,
+    val timing: Set<IntakeSlot>
+)

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDao.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDao.kt
@@ -1,0 +1,14 @@
+package com.example.preventforgettingmedicationandroidapp
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface MedicationDao {
+    @Insert
+    fun insert(medication: Medication)
+
+    @Query("SELECT * FROM medications")
+    fun getAll(): List<Medication>
+}

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDatabase.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDatabase.kt
@@ -1,0 +1,29 @@
+package com.example.preventforgettingmedicationandroidapp
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(entities = [Medication::class], version = 1)
+@TypeConverters(Converters::class)
+abstract class MedicationDatabase : RoomDatabase() {
+    abstract fun medicationDao(): MedicationDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: MedicationDatabase? = null
+
+        fun getInstance(context: Context): MedicationDatabase =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    MedicationDatabase::class.java,
+                    "medications.db"
+                ).allowMainThreadQueries()
+                    .build()
+                    .also { INSTANCE = it }
+            }
+    }
+}

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationRegistrationActivity.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationRegistrationActivity.kt
@@ -1,0 +1,49 @@
+package com.example.preventforgettingmedicationandroidapp
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.RadioButton
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+
+class MedicationRegistrationActivity : AppCompatActivity() {
+    private val dao by lazy { MedicationDatabase.getInstance(this).medicationDao() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_medication_registration)
+
+        val nameInput = findViewById<EditText>(R.id.medication_name)
+        val beforeMeal = findViewById<RadioButton>(R.id.before_meal)
+        val afterMeal = findViewById<RadioButton>(R.id.after_meal)
+        val morning = findViewById<CheckBox>(R.id.slot_morning)
+        val noon = findViewById<CheckBox>(R.id.slot_noon)
+        val evening = findViewById<CheckBox>(R.id.slot_evening)
+        val saveButton = findViewById<Button>(R.id.save_button)
+
+        saveButton.setOnClickListener {
+            val name = nameInput.text.toString().trim()
+            val mealTiming = when {
+                beforeMeal.isChecked -> MealTiming.BEFORE_MEAL
+                afterMeal.isChecked -> MealTiming.AFTER_MEAL
+                else -> null
+            }
+            val slots = mutableSetOf<IntakeSlot>()
+            if (morning.isChecked) slots.add(IntakeSlot.MORNING)
+            if (noon.isChecked) slots.add(IntakeSlot.NOON)
+            if (evening.isChecked) slots.add(IntakeSlot.EVENING)
+
+            if (name.isEmpty() || slots.isEmpty()) {
+                Toast.makeText(this, "Please enter name and select intake times", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
+            val medication = Medication(name = name, mealTiming = mealTiming, timing = slots)
+            dao.insert(medication)
+            Toast.makeText(this, "Medication saved", Toast.LENGTH_SHORT).show()
+            finish()
+        }
+    }
+}

--- a/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_main.xml
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_main.xml
@@ -8,12 +8,21 @@
     tools:context=".MainActivity">
 
     <TextView
+        android:id="@+id/hello_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
+        android:id="@+id/add_medication_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add Medication"
+        app:layout_constraintTop_toBottomOf="@id/hello_text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_medication_registration.xml
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_medication_registration.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <EditText
+            android:id="@+id/medication_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Medication name" />
+
+        <RadioGroup
+            android:id="@+id/meal_timing_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <RadioButton
+                android:id="@+id/before_meal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Before Meal" />
+
+            <RadioButton
+                android:id="@+id/after_meal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="After Meal" />
+        </RadioGroup>
+
+        <CheckBox
+            android:id="@+id/slot_morning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Morning" />
+
+        <CheckBox
+            android:id="@+id/slot_noon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Noon" />
+
+        <CheckBox
+            android:id="@+id/slot_evening"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Evening" />
+
+        <Button
+            android:id="@+id/save_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Save" />
+    </LinearLayout>
+</ScrollView>

--- a/PreventForgettingMedicationAndroidApp/gradle/libs.versions.toml
+++ b/PreventForgettingMedicationAndroidApp/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ appcompat = "1.6.1"
 material = "1.10.0"
 activity = "1.8.0"
 constraintlayout = "2.1.4"
+room = "2.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -19,8 +20,12 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt" }
 


### PR DESCRIPTION
## Summary
- add MealTiming and IntakeSlot enums and Medication model
- set up Room database with DAO and converters
- build medication registration screen and hook from main screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3b2aaee48327b9b4acace4b3b381