### PR TITLE
Add string resources and Japanese localization

### DIFF
--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationRegistrationActivity.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationRegistrationActivity.kt
@@ -36,13 +36,21 @@ class MedicationRegistrationActivity : AppCompatActivity() {
             if (evening.isChecked) slots.add(IntakeSlot.EVENING)
 
             if (name.isEmpty() || slots.isEmpty()) {
-                Toast.makeText(this, "Please enter name and select intake times", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    this,
+                    getString(R.string.error_enter_name_select_times),
+                    Toast.LENGTH_SHORT
+                ).show()
                 return@setOnClickListener
             }
 
             val medication = Medication(name = name, mealTiming = mealTiming, timing = slots)
             dao.insert(medication)
-            Toast.makeText(this, "Medication saved", Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                this,
+                getString(R.string.medication_saved),
+                Toast.LENGTH_SHORT
+            ).show()
             finish()
         }
     }

--- a/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_main.xml
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
         android:id="@+id/hello_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        android:text="@string/hello_world"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -20,7 +20,7 @@
         android:id="@+id/add_medication_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Add Medication"
+        android:text="@string/add_medication"
         app:layout_constraintTop_toBottomOf="@id/hello_text"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_medication_registration.xml
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/res/layout/activity_medication_registration.xml
@@ -13,7 +13,7 @@
             android:id="@+id/medication_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Medication name" />
+            android:hint="@string/medication_name_hint" />
 
         <RadioGroup
             android:id="@+id/meal_timing_group"
@@ -25,37 +25,37 @@
                 android:id="@+id/before_meal"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Before Meal" />
+                android:text="@string/before_meal" />
 
             <RadioButton
                 android:id="@+id/after_meal"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="After Meal" />
+                android:text="@string/after_meal" />
         </RadioGroup>
 
         <CheckBox
             android:id="@+id/slot_morning"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Morning" />
+            android:text="@string/morning" />
 
         <CheckBox
             android:id="@+id/slot_noon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Noon" />
+            android:text="@string/noon" />
 
         <CheckBox
             android:id="@+id/slot_evening"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Evening" />
+            android:text="@string/evening" />
 
         <Button
             android:id="@+id/save_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Save" />
+            android:text="@string/save" />
     </LinearLayout>
 </ScrollView>

--- a/PreventForgettingMedicationAndroidApp/app/src/main/res/values-ja/strings.xml
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,14 @@
+<resources>
+    <string name="app_name">PreventForgettingMedicationAndroidApp</string>
+    <string name="hello_world">こんにちは世界！</string>
+    <string name="add_medication">お薬の登録</string>
+    <string name="medication_name_hint">薬の名前</string>
+    <string name="before_meal">食前</string>
+    <string name="after_meal">食後</string>
+    <string name="morning">朝</string>
+    <string name="noon">昼</string>
+    <string name="evening">夜</string>
+    <string name="save">保存</string>
+    <string name="error_enter_name_select_times">名前を入力し、服用時間を選択してください</string>
+    <string name="medication_saved">お薬を保存しました</string>
+</resources>

--- a/PreventForgettingMedicationAndroidApp/app/src/main/res/values/strings.xml
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/res/values/strings.xml
@@ -1,3 +1,14 @@
 <resources>
     <string name="app_name">PreventForgettingMedicationAndroidApp</string>
+    <string name="hello_world">Hello World!</string>
+    <string name="add_medication">Add Medication</string>
+    <string name="medication_name_hint">Medication name</string>
+    <string name="before_meal">Before Meal</string>
+    <string name="after_meal">After Meal</string>
+    <string name="morning">Morning</string>
+    <string name="noon">Noon</string>
+    <string name="evening">Evening</string>
+    <string name="save">Save</string>
+    <string name="error_enter_name_select_times">Please enter name and select intake times</string>
+    <string name="medication_saved">Medication saved</string>
 </resources>


### PR DESCRIPTION
## Summary
- Replace hardcoded UI text with string resources
- Add Japanese translations for all user-facing strings
- Use string resources in Kotlin Toast messages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb78ad69c8327980aab858dcb751d