### PR TITLE
Enable editing existing medications

### DIFF
--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MainActivity.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.core.view.WindowInsetsCompat
 class MainActivity : AppCompatActivity() {
     private val dao by lazy { MedicationDatabase.getInstance(this).medicationDao() }
     private lateinit var adapter: ArrayAdapter<String>
+    private var medications: List<Medication> = emptyList()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -24,7 +25,14 @@ class MainActivity : AppCompatActivity() {
             insets
         }
         adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, mutableListOf())
-        findViewById<ListView>(R.id.medication_list).adapter = adapter
+        val listView = findViewById<ListView>(R.id.medication_list)
+        listView.adapter = adapter
+        listView.setOnItemClickListener { _, _, position, _ ->
+            val medication = medications[position]
+            val intent = Intent(this, MedicationRegistrationActivity::class.java)
+            intent.putExtra("MED_ID", medication.id)
+            startActivity(intent)
+        }
 
         findViewById<Button>(R.id.add_medication_button).setOnClickListener {
             startActivity(Intent(this, MedicationRegistrationActivity::class.java))
@@ -33,7 +41,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        val medications = dao.getAll()
+        medications = dao.getAll()
         adapter.clear()
         adapter.addAll(medications.map { it.name })
         adapter.notifyDataSetChanged()

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDao.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDao.kt
@@ -3,12 +3,19 @@ package com.example.preventforgettingmedicationandroidapp
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 
 @Dao
 interface MedicationDao {
     @Insert
     fun insert(medication: Medication)
 
+    @Update
+    fun update(medication: Medication)
+
     @Query("SELECT * FROM medications")
     fun getAll(): List<Medication>
+
+    @Query("SELECT * FROM medications WHERE id = :id")
+    fun getById(id: Int): Medication?
 }

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationRegistrationActivity.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationRegistrationActivity.kt
@@ -23,6 +23,21 @@ class MedicationRegistrationActivity : AppCompatActivity() {
         val evening = findViewById<CheckBox>(R.id.slot_evening)
         val saveButton = findViewById<Button>(R.id.save_button)
 
+        val medId = intent.getIntExtra("MED_ID", -1)
+        val existingMedication = if (medId != -1) dao.getById(medId) else null
+
+        existingMedication?.let { medication ->
+            nameInput.setText(medication.name)
+            when (medication.mealTiming) {
+                MealTiming.BEFORE_MEAL -> beforeMeal.isChecked = true
+                MealTiming.AFTER_MEAL -> afterMeal.isChecked = true
+                else -> {}
+            }
+            morning.isChecked = medication.timing.contains(IntakeSlot.MORNING)
+            noon.isChecked = medication.timing.contains(IntakeSlot.NOON)
+            evening.isChecked = medication.timing.contains(IntakeSlot.EVENING)
+        }
+
         saveButton.setOnClickListener {
             val name = nameInput.text.toString().trim()
             val mealTiming = when {
@@ -44,8 +59,18 @@ class MedicationRegistrationActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
-            val medication = Medication(name = name, mealTiming = mealTiming, timing = slots)
-            dao.insert(medication)
+            val medication = Medication(
+                id = if (medId != -1) medId else 0,
+                name = name,
+                mealTiming = mealTiming,
+                timing = slots
+            )
+
+            if (medId != -1) {
+                dao.update(medication)
+            } else {
+                dao.insert(medication)
+            }
             Toast.makeText(
                 this,
                 getString(R.string.medication_saved),


### PR DESCRIPTION
## Summary
- Add update and lookup methods to MedicationDao
- Load existing medication data in MedicationRegistrationActivity for editing
- Send selected medication ID from MainActivity to support editing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe9954c88327a8c58a74e46bd2eb