### PR TITLE
Enable medication deletion via long-press in list

### DIFF
--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MainActivity.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MainActivity.kt
@@ -1,9 +1,10 @@
 package com.example.preventforgettingmedicationandroidapp
 
+import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Button
 import android.widget.ArrayAdapter
+import android.widget.Button
 import android.widget.ListView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -33,6 +34,18 @@ class MainActivity : AppCompatActivity() {
             intent.putExtra("MED_ID", medication.id)
             startActivity(intent)
         }
+        listView.setOnItemLongClickListener { _, _, position, _ ->
+            val medication = medications[position]
+            AlertDialog.Builder(this)
+                .setMessage("Delete this medication?")
+                .setPositiveButton("Yes") { _, _ ->
+                    dao.delete(medication)
+                    loadMedications()
+                }
+                .setNegativeButton("No", null)
+                .show()
+            true
+        }
 
         findViewById<Button>(R.id.add_medication_button).setOnClickListener {
             startActivity(Intent(this, MedicationRegistrationActivity::class.java))
@@ -41,6 +54,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        loadMedications()
+    }
+
+    private fun loadMedications() {
         medications = dao.getAll()
         adapter.clear()
         adapter.addAll(medications.map { it.name })

--- a/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDao.kt
+++ b/PreventForgettingMedicationAndroidApp/app/src/main/java/com/example/preventforgettingmedicationandroidapp/MedicationDao.kt
@@ -1,6 +1,7 @@
 package com.example.preventforgettingmedicationandroidapp
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
@@ -18,4 +19,7 @@ interface MedicationDao {
 
     @Query("SELECT * FROM medications WHERE id = :id")
     fun getById(id: Int): Medication?
+
+    @Delete
+    fun delete(medication: Medication)
 }


### PR DESCRIPTION
## Summary
- allow removing medications through `@Delete` DAO method
- add long-press handler with confirmation dialog to delete a medication and refresh list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc1c242fc8327bc4c1509c7695743